### PR TITLE
Update search api to correctly wrap author elements.

### DIFF
--- a/modules/content-negotiation/content-negotiation.xql
+++ b/modules/content-negotiation/content-negotiation.xql
@@ -79,11 +79,15 @@ declare function local:search-element($element as xs:string?, $q as xs:string*, 
                                         <ptr target="{$recID}"/>
                                     </bibl>    
                                 else if(request:get-parameter('wrapElement', '') != '') then
-                                    element {xs:QName(request:get-parameter('wrapElement', ''))}
-                                        {attribute { "ref" } { $recID }, 
-                                            element {xs:QName($element)}
-                                            {attribute { "ref" } { $recID }, $headword[1] }
-                                        }
+                                    if(request:get-parameter('wrapElement', '') = 'author') then 
+                                        element {xs:QName(request:get-parameter('wrapElement', ''))}
+                                            {attribute { "ref" } { $recID }, $headword[1]}
+                                    else 
+                                        element {xs:QName(request:get-parameter('wrapElement', ''))}
+                                            {attribute { "ref" } { $recID }, 
+                                                element {xs:QName($element)}
+                                                {attribute { "ref" } { $recID }, $headword[1] }
+                                            }
                                 else 
                                     element {xs:QName($element)}
                                         {attribute { "ref" } { $recID }, $headword[1] }


### PR DESCRIPTION
Fixes incorrectly nested persName elements on manuForma author lookup. 

See: https://github.com/majlis-erc/manuForma/issues/564